### PR TITLE
Fixes article link and a typo

### DIFF
--- a/_posts/2020-02-15-random-forest-is-not-calibrated.md
+++ b/_posts/2020-02-15-random-forest-is-not-calibrated.md
@@ -74,7 +74,7 @@ We see that predictions coming out of the logistic regression are much closer to
 
 What would using the probabilities coming out of the random forest classifier mean in practice for our business decisions?
 
-* For the customers that we believe have an ~70% chance of wearing a size 10, more ~90% of them actually will. Because of the lower reported probability, some of them will get clothing of the wrong size and be unhappy with their purchases (or request costly refunds and exchanges).
+* For the customers that we believe have an ~70% chance of wearing a size 10, more than ~90% of them actually will. Because of the lower reported probability, some of them will get clothing of the wrong size and be unhappy with their purchases (or request costly refunds and exchanges).
 * Of the customer reviews that the classifier scores as having a 65% probability of being spam (and therefore do not get filtered out of the data set), more than 80% of them will actually be spam. 
 * Our "Get out the Vote" campaign will miss a huge number of people. The group of people who are predicted to have a probability of voting of 40% (and thus would not receive a postcard) have an actual rate of voting of less than 20% (and should have received a postcard). 
 

--- a/_posts/2020-02-16-calibrating-random-forest.md
+++ b/_posts/2020-02-16-calibrating-random-forest.md
@@ -4,7 +4,7 @@ date:   2020-02-16 7:00:00 -0700
 categories: python data_science
 ---
 
-In the previous [blog post](https://dataisblue.io/python,/data/science/2020/02/15/random-forest-is-not-calibrated.html) , we looked at the probability predictions that come out of naive implementation of the `scikit-learn` Random Forest classifier. We noted that the predictions are not well-calibrated, but did not address how to fix that problem, which is the subject of this blog post.
+In the previous [blog post](https://dataisblue.io/python/data_science/2020/02/15/random-forest-is-not-calibrated.html) , we looked at the probability predictions that come out of naive implementation of the `scikit-learn` Random Forest classifier. We noted that the predictions are not well-calibrated, but did not address how to fix that problem, which is the subject of this blog post.
 
 <!--more-->
 


### PR DESCRIPTION
FYI: When you change category tags on an article, you also change the URL since the tags are embedded in the url slug
